### PR TITLE
fixed BASH error handling so full T2 processing can run

### DIFF
--- a/bb_structural_pipeline/bb_struct_init
+++ b/bb_structural_pipeline/bb_struct_init
@@ -98,11 +98,13 @@ rm grot*
 
 
 #Clean and reorganize
+# add "|| true" to end of mv functions so rest of pipeline
+# can run if files don't exist
 rm *tmp*
 mkdir transforms
-mv *MNI* transforms
-mv *warp*.* transforms
-mv *_to_* transforms
+mv *MNI* transforms || true
+mv *warp*.* transforms || true
+mv *_to_* transforms || true
 mv transforms/T1_brain_to_MNI.nii.gz .
 
 cd ..

--- a/init_vars
+++ b/init_vars
@@ -80,4 +80,4 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:../software/MCR_2014a_glnxa64/v83/runti
 
 export XAPPLRESDIR=../software/MCR_2014a_glnxa64/v83/X11/app-defaults
 
-conda activate ../../software/env
+conda activate /liberatrix/mcintosh_lab/ukbb/software/env


### PR DESCRIPTION
Note: this merge will make the conda activate statement in `init_vars` point to the environment at /liberatrix/mcintosh_lab/ukbb for now. This is so you can source the `init_vars` from anywhere and it'll activate the environment.