### PR TITLE
found FIX training data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 .*.sw[op]
 .nfs*
 bb_python/python_installation/gradunwarp_FMRIB/
+*.RData
 

--- a/bb_functional_pipeline/bb_fix_dir/training_files/UKBiobank.RData.txt
+++ b/bb_functional_pipeline/bb_fix_dir/training_files/UKBiobank.RData.txt
@@ -1,3 +1,3 @@
-File UKBiobank.RData is neded for FIX. It can be downloaded from:
+File UKBiobank.RData is neded for FIX. It can be found in:
 
-www.fmrib.ox.ac.uk/datasets/ukbiobank/UKBiobank.RData
+/liberatrix/mcintosh_lab/kshen/ukbb/UK_biobank_pipeline_v_1/bb_functional_pipeline/bb_fix_dir/training_files/UKBiobank.RData


### PR DESCRIPTION
Found the FIX training data from the FIX package distributed here: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FIX/UserGuide

It's too large to commit to the remote repository so its location is noted in the .txt file