### PR TITLE
finally fixed bedpostx to submit in parallel

### DIFF
--- a/bb_diffusion_pipeline/bb_bedpostx/bb_bedpostx_gpu
+++ b/bb_diffusion_pipeline/bb_bedpostx/bb_bedpostx_gpu
@@ -27,6 +27,10 @@ subjdir=`fsl_abspath $1`
 subjdir=`echo ${subjdir} | sed 's/\/$/$/g'`
 echo subjectdir is $subjdir
 
+FSLSUBALREADYRUN=false
+echo $FSLSUBALREADYRUN
+
+
 if [ -d ${subjdir} ] ; then
 
     if [ ! -f ${subjdir}/pre_bedpostx_error.txt ] ; then


### PR DESCRIPTION
reset FSLSUBALREADYRUN flag to false before bedpostx call (since bedpostx itself is a wrapper for fsl_sub); this allows bedpostx to queue slices as an array job