### PR TITLE
added workaround for massive bedpostx log issue

### DIFF
--- a/bb_diffusion_pipeline/bb_bedpostx/bb_bedpostx_gpu
+++ b/bb_diffusion_pipeline/bb_bedpostx/bb_bedpostx_gpu
@@ -48,6 +48,13 @@ if [ -d ${subjdir} ] ; then
 	    sleep 1
         done
 	sleep 1m
+	edir=$PWD
+	for entry in `ls ${subjdir}/bedpostx.bedpostX/logs/monitor`; do
+    	    var=$(expr 4 - ${#entry})
+    	    cd ${subjdir}/bedpostx.bedpostX/logs
+    	    ls | grep -P "^log0{$var}${entry}$" | xargs -d "\n" rm
+	done
+	cd $edir
     fi
 else
     echo "It was not possible to run BEDPOSTX on the subject. Check bedpostx directory"


### PR DESCRIPTION
this added snippet will check for created (and finished) log files and remove them as they are added. a full fix would require editing bedpost itself so this is the next best solution