### PR TITLE
Cam can t1 fixes

### DIFF
--- a/bb_diffusion_pipeline/bb_pipeline_diff.py
+++ b/bb_diffusion_pipeline/bb_pipeline_diff.py
@@ -94,18 +94,18 @@ def bb_pipeline_diff(subject, jobHold, fileConfiguration):
         + baseDir
         + "/dMRI/dMRI/dti",
     )
-    jobTBSS = LT.runCommand(
-        logger,
-        #'${FSLDIR}/bin/fsl_sub -T 240 -N "bb_tbss_'
-        '${FSLDIR}/bin/fsl_sub -q ${QUEUE_STANDARD} -N "bb_tbss_'
-        + subname
-        + '" -j '
-        + jobDTIFIT
-        + "  -l "
-        + logDir
-        + " $BB_BIN_DIR/bb_diffusion_pipeline/bb_tbss/bb_tbss_general "
-        + subject,
-    )
+    #jobTBSS = LT.runCommand(
+    #    logger,
+    #    #'${FSLDIR}/bin/fsl_sub -T 240 -N "bb_tbss_'
+    #    '${FSLDIR}/bin/fsl_sub -q ${QUEUE_STANDARD} -N "bb_tbss_'
+    #    + subname
+    #    + '" -j '
+    #    + jobDTIFIT
+    #    + "  -l "
+    #    + logDir
+    #    + " $BB_BIN_DIR/bb_diffusion_pipeline/bb_tbss/bb_tbss_general "
+    #    + subject,
+    #)
     # jobNODDI = LT.runCommand(
     # logger,
     ##'${FSLDIR}/bin/fsl_sub -T 100 -N "bb_NODDI_'

--- a/bb_structural_pipeline/bb_struct_init
+++ b/bb_structural_pipeline/bb_struct_init
@@ -37,7 +37,8 @@ fi
 #Calculate and apply the Gradient Distortion Unwarp ###NO GDC###
 # $BB_BIN_DIR/bb_pipeline_tools/bb_GDC --workingdir=./T1_GDC/ --in=T1_orig.nii.gz --out=T1_orig_ud.nii.gz --owarp=T1_orig_ud_warp.nii.gz
 
-cp T1_orig.nii.gz T1_orig_ud.nii.gz
+#reorient T1 images to std
+fslreorient2std T1_orig.nii.gz T1_orig_ud.nii.gz
 
 #Calculate where does the brain start in the z dimension and then extract the roi
 head_top=`${FSLDIR}/bin/robustfov -i T1_orig_ud | grep -v Final | head -n 1 | awk '{print $5}'`


### PR DESCRIPTION
Reorient T1 images to standard before registration to MNI; Closes issue #76 

Also turned off TBSS part of dMRI subpipe